### PR TITLE
AutoFix tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All data (papers, tools, news, etc.) is stored in JSON format (see `data` direct
 
 To update information on the website:
 
-1. Install Python 3 and pystache (e.g. `aptitude install python-pystache`).
+1. Install Python 3 and pystache (e.g. `aptitude install python3-pystache`).
 2. Modify files in the `data` directory.
 3. Run build script (e.g. `python3 build.py`).
 4. Open `index.html` in your browser to verify your modifications.

--- a/data/tools.json
+++ b/data/tools.json
@@ -21,6 +21,16 @@
 	    "year": "2013"
 	},
 	{
+	    "name": "AutoFix",
+	    "description": "Automatic program repair of object-oriented programs with contracts",
+	    "url": "https://bit.ly/autofix-tool",
+	    "target": "Eiffel source code",
+	    "title": "Automated Fixing of Programs with Contracts",
+	    "authors": "Y. Pei, C. A. Furia, M. Nordio, Y. Wei, B. Meyer, A. Zeller",
+	    "venue": "IEEE Transactions on Software Engineering (TSE)",
+	    "year": "2014"
+	},
+	{
 	    "name": "Nopol",
 	    "description": "Automated program repair tool for conditional expressions",
 	    "url": "https://github.com/SpoonLabs/nopol/",

--- a/tools.html
+++ b/tools.html
@@ -89,6 +89,36 @@
             </tbody>
           </table>
         </div>
+        <h1>AutoFix</h1>
+        <div class="table-responsive tool-table">
+          <table class="table">
+            <thead>
+              <tr>
+                <th> </th>
+                <th> </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Description</td>
+                <td>Automatic program repair of object-oriented programs with contracts</td>
+              </tr>
+              <tr>
+                <td>URL </td>
+                <td><a href="https://bit.ly/autofix-tool"><span style="text-decoration: underline;">https://bit.ly/autofix-tool</span></a> </td>
+              </tr>
+              <tr>
+                <td>Target</td>
+                <td>Eiffel source code</td>
+              </tr>
+              <tr>
+                <td>Related publication</td>
+                <td><strong>Automated Fixing of Programs with Contracts</strong>, by Y. Pei, C. A. Furia, M. Nordio, Y. Wei, B. Meyer, A. Zeller. <em>IEEE Transactions on Software Engineering (TSE)</em>.
+                  2014 </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <h1>Nopol</h1>
         <div class="table-responsive tool-table">
           <table class="table">


### PR DESCRIPTION
I've added an entry for the AutoFix tool page. I inferred that the tools are listed in chronological order according to the year of the "Related publication" listed there. Feel free to change the order if another criterion applies.

Unrelated to the tools page, I noticed that the `README.md` file listed package `python-pystache` but the version for Python 3 is actually called `python3-pystache`, so I edited this detail too if useful.